### PR TITLE
Add slowdown when player is in the air

### DIFF
--- a/src/objects/player.lua
+++ b/src/objects/player.lua
@@ -68,9 +68,9 @@ return {
         else
             if not self.jump_enabled and not self.is_walking then
                 if self.dx > 0 then
-                    self.dx = math.max(self.dx - self.passive_decel / 1.5 * dt, 0)
+                    self.dx = math.max(self.dx - (self.passive_decel / 1.5) * dt, 0)
                 else
-                    self.dx = math.min(self.dx + self.passive_decel / 1.5 * dt, 0)
+                    self.dx = math.min(self.dx + (self.passive_decel / 1.5) * dt, 0)
                 end
             else
                 if self.jump_enabled and not self.is_walking then

--- a/src/objects/player.lua
+++ b/src/objects/player.lua
@@ -66,11 +66,19 @@ return {
                 self.dx = math.min(self.dx + self.crouch_decel * dt, 0)
             end
         else
-            if self.jump_enabled and not self.is_walking then
+            if not self.jump_enabled and not self.is_walking then
                 if self.dx > 0 then
-                    self.dx = math.max(self.dx - self.passive_decel * dt, 0)
+                    self.dx = math.max(self.dx - self.passive_decel / 1.5 * dt, 0)
                 else
-                    self.dx = math.min(self.dx + self.passive_decel * dt, 0)
+                    self.dx = math.min(self.dx + self.passive_decel / 1.5 * dt, 0)
+                end
+            else
+                if self.jump_enabled and not self.is_walking then
+                    if self.dx > 0 then
+                        self.dx = math.max(self.dx - self.passive_decel * dt, 0)
+                    else
+                        self.dx = math.min(self.dx + self.passive_decel * dt, 0)
+                    end
                 end
             end
         end


### PR DESCRIPTION
# Player Air Slowdown
Currently the player does not decelerate horizontally when in the air, leading to some awkward movement.

## What changed?
This PR adds slowdown at a decreased rate when the player is in the air.