### PR TITLE
Add object types to map section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ Boom uses Love2d's builtin physics engine, [Box2D](http://box2d.org/about/).
       <img src="https://avatars1.githubusercontent.com/u/35495466?s=460&v=4"
         width=128px>
       <h3><a href="https://github.com/quigley-c">Carson Quigley</a></h3>
-      <h4><a href="https://quigleyc.com">site</a><h4>
+      <h4><a href="https://quigleyc.com">quigleyc.com</a><h4>
     </td>
     <td align="center">
       <a href="https://github.com/codeandkey">
       <img src="https://avatars1.githubusercontent.com/u/3630356?s=460&v=4"
         width=128px>
       <h3><a href="https://github.com/codeandkey">Justin S</a></h3>
-      <h4><a href="https://codeandkey.github.io">site</a><h4>
+      <h4><a href="https://codeandkey.github.io">codeandkey.github.io</a><h4>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ In the `src/assets` directory you will find Boom's object types and tilesets
 which can be imported into the map editor.
 
 Some useful object types:
+- `player` is the player spawn point.
 - `noclip` is solid ground that players can move and jump on.
+- `physbox` is a physics object. Requires `type` string parameter.
+	- setting `type` to `dynamic` allows interaction with other objects.
+	- setting `type` to `static` forces a static object.
 
 ## Boom. Physics.
 


### PR DESCRIPTION
# Add map objects
Currently the README only lists `noclip` as a map object.

## What changed?
This PR adds documentation of objects to be used when creating maps.