### PR TITLE
Use nearest texture filtering

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -9,7 +9,7 @@ function love.load()
     -- initial graphics setup
     
     -- use nearest filtering over "blurry" linear filtering
-    love.graphics.setDefaultFilter('nearest')
+    love.graphics.setDefaultFilter('linear', 'nearest')
 
     map.load('test')
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -7,7 +7,7 @@ local map = require 'map'
 
 function love.load()
     -- initial graphics setup
-    
+
     -- use nearest filtering over "blurry" linear filtering
     love.graphics.setDefaultFilter('linear', 'nearest')
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -6,6 +6,11 @@
 local map = require 'map'
 
 function love.load()
+    -- initial graphics setup
+    
+    -- use nearest filtering over "blurry" linear filtering
+    love.graphics.setDefaultFilter('nearest')
+
     map.load('test')
 end
 


### PR DESCRIPTION
Nearest texture filtering makes our low-resolution sprites look much sharper:

| linear | nearest |
| :---: | :---: |
| ![linear](https://i.imgur.com/ub61VCa.png) | ![nearest](https://i.imgur.com/xMEflYa.png) |