### PR TITLE
Physics debugging, nade bugfix

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -15,4 +15,8 @@ end
 
 function love.draw()
     map.render()
+
+    if love.keyboard.isDown('p') then
+        map.render_phys_debug()
+    end
 end

--- a/src/map.lua
+++ b/src/map.lua
@@ -143,4 +143,27 @@ function map.get_physics_world()
     return map.current.phys_world
 end
 
+--[[
+    map.render_phys_debug()
+
+    renders physics debugging information
+--]]
+
+function map.render_phys_debug()
+    love.graphics.setColor(0, 0, 1, 1)
+
+    for _, body in ipairs(map.current.phys_world:getBodies()) do
+        for _, fixture in ipairs(body:getFixtures()) do
+            local shape = fixture:getShape()
+            local shape_type = shape:getType()
+
+            if shape_type == 'polygon' then
+                love.graphics.polygon('line', body:getWorldPoints(shape:getPoints()))
+            elseif shape_type == 'circle' then
+                love.graphics.circle('line', body:getX(), body:getY(), shape:getRadius())
+            end
+        end
+    end
+end
+
 return map

--- a/src/objects/nade.lua
+++ b/src/objects/nade.lua
@@ -43,6 +43,7 @@ return {
 
     destroy = function(self)
         obj.create(self.__layer, 'explosion', {x = self.body:getX(), y = self.body:getY()})
+        self.body:destroy()
     end,
 
     update = function(self, dt)


### PR DESCRIPTION
This PR adds a physics debugging mode which can be activated by holding `P`.
This also fixes grenade leaving behind rogue invisible physics bodies which sometimes caused some weird behavior.