### PR TITLE
Fix crash on enemy death

### DIFF
--- a/src/objects/enemy_bomber.lua
+++ b/src/objects/enemy_bomber.lua
@@ -56,14 +56,32 @@ return {
         })
 
         obj.create(self.__layer, 'gib', {
-            img = '19x13_player_body.png',
+            img = '14x13_player_body.png',
             x = self.x + 8, y = self.y + 8,
             color = self.color
         })
 
         obj.create(self.__layer, 'gib', {
-            img = '11x10_player_legs.png',
-            x = self.x + 13, y = self.y + 22,
+            img = '5x9_player_leg.png',
+            x = self.x + 14, y = self.y + 23,
+            color = self.color
+        })
+
+        obj.create(self.__layer, 'gib', {
+            img = '5x9_player_leg.png',
+            x = self.x + 18, y = self.y + 23,
+            color = self.color
+        })
+
+        obj.create(self.__layer, 'gib', {
+            img = '6x13_player_arm.png',
+            x = self.x + 8, y = self.y + 8,
+            color = self.color
+        })
+
+        obj.create(self.__layer, 'gib', {
+            img = '6x13_player_arm.png',
+            x = self.x + 18, y = self.y + 8,
             color = self.color
         })
 


### PR DESCRIPTION
`master` as-is will crash if the enemy is killed because it uses the older 3-part gibs which no longer exist.