### PR TITLE
Make camera follow player's head on death

### DIFF
--- a/src/objects/gib.lua
+++ b/src/objects/gib.lua
@@ -33,6 +33,11 @@ return {
 
         -- set the physics mask
         self.fixture:setMask(physics_groups.GIB, physics_groups.PHYSBOX)
+
+        -- allow camera transfer
+        self.give_camera = function(this, camera)
+            this.camera = camera
+        end
     end,
 
     destroy = function(self)
@@ -57,6 +62,12 @@ return {
 
         self.x, self.y = self.body:getPosition()
         self.angle = self.body:getAngle()
+
+        if self.camera then
+            self.camera:set_focus(self.x, self.x + self.w,
+                                  self.y, self.y + self.h,
+                                  true, 0, 0, 'right')
+        end
     end,
 
     render = function(self)

--- a/src/objects/player.lua
+++ b/src/objects/player.lua
@@ -35,16 +35,22 @@ return {
         self.spr:play()
 
         -- create a camera for the player
-        self.camera = obj.create(self.__layer, 'camera', { x = self.x + self.w / 2, y = self.y + self.h / 2 })
+        self.camera = obj.create(self.__layer, 'camera', {
+            x = self.x + self.w / 2,
+            y = self.y + self.h / 2,
+        })
     end,
     explode = function(self, _, _)
         -- turn the player into gibs
-        obj.create(self.__layer, 'gib', { img = '12x9_player_head.png', x = self.x + 11, y = self.y })
+        local head = obj.create(self.__layer, 'gib', { img = '12x9_player_head.png', x = self.x + 11, y = self.y })
         obj.create(self.__layer, 'gib', { img = '14x13_player_body.png', x = self.x + 8, y = self.y + 8 })
         obj.create(self.__layer, 'gib', { img = '5x9_player_leg.png', x = self.x + 14, y = self.y + 23 })
         obj.create(self.__layer, 'gib', { img = '5x9_player_leg.png', x = self.x + 18, y = self.y + 23 })
         obj.create(self.__layer, 'gib', { img = '6x13_player_arm.png', x = self.x + 18, y = self.y + 8 })
         obj.create(self.__layer, 'gib', { img = '6x13_player_arm.png', x = self.x + 8, y = self.y + 8 })
+
+        -- point the camera to the head
+        head:give_camera(self.camera)
 
         obj.destroy(self)
     end,


### PR DESCRIPTION
This adds a camera passthrough to the gib object, allowing the player to transfer the camera's focus to the gib object.