### PR TITLE
Implement camera auto scaling

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -8,6 +8,7 @@ local camera = {
     scale = 2, -- pixel scale (effective viewport size)
     focus_x = 0,
     focus_y = 0,
+    max_game_width = 640, -- maximum camera width in game coordinates
 
     focus_box = {
         left = 0.3,
@@ -86,6 +87,17 @@ function camera.apply()
     if camera.shake_time > 0 then
         love.graphics.translate(((math.random() * 2) - 1) * camera.shake_time * camera.shake_factor,
                                 ((math.random() * 2) - 1) * camera.shake_time * camera.shake_factor)
+    end
+end
+
+--- Update the camera's scale from a display size.
+-- Should be called whenever the framebuffer is resized.
+-- @param w Framebuffer width.
+function camera.rescale(w)
+    camera.scale = 1
+
+    while w / camera.scale > camera.max_game_width do
+        camera.scale = camera.scale + 1
     end
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -10,10 +10,16 @@ local log    = require 'log'
 local map    = require 'map'
 
 function love.load()
+    love.window.setFullscreen(true)
     love.graphics.setDefaultFilter('nearest', 'nearest')
 
     map.load('test')
     log.info('Finished loading.')
+end
+
+function love.resize(w, h)
+    log.debug('Display resized to %d by %d', w, h)
+    camera.rescale(w)
 end
 
 function love.keypressed(key)


### PR DESCRIPTION
This implements a smart camera scale; whenever the display is resized the camera's pixel scale is updated to one that keeps the game camera a sane size.

The camera pixel scale is always an integer so game pixels will always be crisp.
This also fullscreens the game by default in the entry point.