### PR TITLE
Add smooth, safer map transitions

### DIFF
--- a/src/object_types/main_menu.lua
+++ b/src/object_types/main_menu.lua
@@ -151,7 +151,7 @@ return {
                 if this.main_menu_option == 1 then
                     -- New game!
                     -- Load the main map.
-                    map.load('test')
+                    map.request('test')
                 elseif this.main_menu_option == 2 then
                     this.state = this.STATE_OPTIONS
                     this.option = 1


### PR DESCRIPTION
This implements a new function `map.request` to request a map transition. The screen will fade out, wait a short time and then load the next map. The next map will fade in as well.