### PR TITLE
Add background property to tile layers

### DIFF
--- a/src/map.lua
+++ b/src/map.lua
@@ -110,7 +110,12 @@ function map.render()
 
     for _, v in ipairs(map.current.layers) do
         if v.type == 'tilelayer' then
-            tile_layer.render(v)
+            -- Render background layers at half brightness.
+            if v.properties.background then
+                tile_layer.render(v, {0.5, 0.5, 0.5, 1})
+            else
+                tile_layer.render(v)
+            end
         elseif v.type == 'objectgroup' then
             object_group.call(v, 'render')
         end

--- a/src/tile_layer.lua
+++ b/src/tile_layer.lua
@@ -68,8 +68,8 @@ end
 
 --- Render a tile layer.
 -- @param layer Tile layer to render.
-function tile_layer.render(layer)
-    love.graphics.setColor(1, 1, 1, 1)
+function tile_layer.render(layer, color)
+    love.graphics.setColor(color or {1, 1, 1, 1})
     love.graphics.draw(layer.batch)
 end
 


### PR DESCRIPTION
Setting the boolean `background` property on a tile layer will render it at half brightness.
The alpha is unmodified.