### PR TITLE
Implement player death sequence, time control, post-processing pipeline

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -9,6 +9,7 @@ local camera = {
     x = 0, -- center coordinates
     y = 0,
     scale = 2, -- pixel scale (effective viewport size)
+    escale = 0, -- extra scale
     focus_x = 0,
     focus_y = 0,
     panic_x = 0,
@@ -56,11 +57,17 @@ function camera.setscale(scale)
     camera.scale = scale
 end
 
+--- Sets an additonal camera scale. This is added to the normal scale.
+-- @param escale Extra scale.
+function camera.setescale(escale)
+    camera.escale = escale
+end
+
 --- Get the camera bounding rectangle.
 -- @return Table with _x_, _y_, _w_, _h_ in world space.
 function camera.get_bounds()
     local sw, sh = love.graphics.getDimensions()
-    local cw, ch = (sw / camera.scale), (sh / camera.scale)
+    local cw, ch = (sw / (camera.scale + camera.escale)), (sh / (camera.scale + camera.escale))
 
     return {
         x = camera.x - cw / 2,
@@ -85,7 +92,7 @@ function camera.apply()
 
     love.graphics.push()
     love.graphics.translate(sw / 2, sh / 2)
-    love.graphics.scale(camera.scale)
+    love.graphics.scale(camera.scale + camera.escale)
     love.graphics.translate(-camera.x, -camera.y)
 
     -- Apply extra translate if shaking.

--- a/src/component_types/character.lua
+++ b/src/component_types/character.lua
@@ -68,6 +68,8 @@ return {
             spr_name = '12x9_player_head.png',
             x = sprite_left + 11,
             y = this.y,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
 
@@ -75,6 +77,8 @@ return {
             spr_name = '14x13_player_body.png',
             x = sprite_left + 8,
             y = this.y + 8,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
 
@@ -82,6 +86,8 @@ return {
             spr_name = '5x9_player_leg.png',
             x = sprite_left + 14,
             y = this.y + 22,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
 
@@ -89,6 +95,8 @@ return {
             spr_name = '5x9_player_leg.png',
             x = sprite_left + 18,
             y = this.y + 22,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
 
@@ -96,6 +104,8 @@ return {
             spr_name = '6x13_player_arm.png',
             x = sprite_left + 8,
             y = this.y + 8,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
 
@@ -103,6 +113,8 @@ return {
             spr_name = '6x13_player_arm.png',
             x = sprite_left + 18,
             y = this.y + 8,
+            dx = this.dx,
+            dy = this.dy,
             color = this.color,
         })
     end,

--- a/src/component_types/character.lua
+++ b/src/component_types/character.lua
@@ -70,6 +70,7 @@ return {
             y = this.y,
             dx = this.dx,
             dy = this.dy,
+            flip = (this.direction == 'left'),
             color = this.color,
         })
 

--- a/src/component_types/character.lua
+++ b/src/component_types/character.lua
@@ -64,7 +64,7 @@ return {
 
         local sprite_left = this.x + this.spr_offsetx
 
-        object_group.create_object(this.__layer, 'gib', {
+        this.follow_gib = object_group.create_object(this.__layer, 'gib', {
             spr_name = '12x9_player_head.png',
             x = sprite_left + 11,
             y = this.y,

--- a/src/main.lua
+++ b/src/main.lua
@@ -9,6 +9,7 @@ local input  = require 'input'
 local log    = require 'log'
 local map    = require 'map'
 local opts   = require 'opts'
+local post   = require 'post'
 
 function love.load()
     -- Load game. Check first: is there a saved mode? If so, apply it.
@@ -73,8 +74,9 @@ function love.update(dt)
 end
 
 function love.draw()
-    -- Render the current map with the camera applied.
+    post.begin_frame()
     camera.apply()
     map.render()
     camera.unapply()
+    post.end_frame()
 end

--- a/src/map.lua
+++ b/src/map.lua
@@ -44,6 +44,9 @@ function map.load(name, packed_args)
     -- Initialize tilesets.
     map.current.tilesets = tilesets.init(map.current.tilesets)
 
+    -- Set default time divisor.
+    map.current.time_div = 1
+
     -- Initialize layers.
     for k, v in ipairs(map.current.layers) do
         if v.type == 'tilelayer' then
@@ -128,6 +131,9 @@ function map.update(dt)
         return
     end
 
+    -- Apply time divisor.
+    dt = dt / map.current.time_div
+
     -- Perform transition logic if a transition is happening.
     if map.requested ~= nil then
         if map.fade_alpha < 1 then
@@ -202,6 +208,13 @@ function map.find_layer(name)
             return v
         end
     end
+end
+
+--- Sets the time divisor for the current map.
+-- A value of 2 will make the map run at half speed.
+-- @param div Time divisor.
+function map.set_time_div(div)
+    map.current.time_div = div
 end
 
 --- Find an object by name.

--- a/src/object.lua
+++ b/src/object.lua
@@ -129,4 +129,16 @@ function object.add_component(obj, type_name, initial)
     log.debug('Added component of type %s to object type %s', type_name, obj.__typename)
 end
 
+--- Remove a component from an object.
+-- @param obj Object to remove from.
+-- @param type_name Component to remove.
+function object.del_component(obj, type_name)
+    if obj.components[type_name] then
+        object.call(obj.components[type_name], 'destroy')
+        obj.components[type_name] = nil
+    else
+        log.warn('Cannot remove component type %s from object %s: no component!', type_name, obj.__typename)
+    end
+end
+
 return object

--- a/src/object_types/explosion.lua
+++ b/src/object_types/explosion.lua
@@ -8,9 +8,9 @@ return {
     init = function(this)
         -- Configuration.
         this.resolution   = this.resolution or 100
-        this.radius       = this.radius or 300
+        this.radius       = this.radius or 100
         this.object_range = this.object_range or 100
-        this.intensity    = this.intensity or 35
+        this.intensity    = this.intensity or 5
         this.num_casts    = this.num_casts or 5 -- number of times rays sent out after init
 
         -- Look for nearby objects to explode.
@@ -43,7 +43,7 @@ return {
                             y = y - this.y,
                         }
 
-                        local impulse_length = fraction * this.radius
+                        local impulse_length = (1.0 - fraction) * this.radius
 
                         impulse_vector.x = impulse_vector.x * this.intensity / impulse_length
                         impulse_vector.y = impulse_vector.y * this.intensity / impulse_length

--- a/src/object_types/gib.lua
+++ b/src/object_types/gib.lua
@@ -17,6 +17,7 @@ return {
 
         this.wait = this.wait or 5
         this.color = this.color or {1, 1, 1, 1}
+        this.flip = this.flip or false
 
         this.shape = love.physics.newRectangleShape(this.w, this.h)
         this.body = love.physics.newBody(map.get_physics_world(), this.x + this.w / 2, this.y + this.h / 2, 'dynamic')
@@ -54,6 +55,6 @@ return {
         this.y = this.body:getY() - this.h / 2
 
         love.graphics.setColor(this.color)
-        sprite.render(this.spr, this.x, this.y, this.angle)
+        sprite.render(this.spr, this.x, this.y, this.angle, this.flip)
     end,
 }

--- a/src/object_types/gib.lua
+++ b/src/object_types/gib.lua
@@ -9,6 +9,8 @@ return {
     init = function(this)
         this.x = this.x or 0
         this.y = this.y or 0
+        this.dx = this.dx or 0
+        this.dy = this.dy or 0
 
         this.spr = sprite.create(this.spr_name)
         this.w, this.h = sprite.frame_size(this.spr)
@@ -24,6 +26,7 @@ return {
         this.fixture:setMask(physics_groups.GIB)
         this.fixture:setRestitution(0.1)
 
+        this.body:setLinearVelocity(this.dx, this.dy)
         this.body:applyAngularImpulse(math.random(-10, 10))
         this.body:setAngle(this.angle or 0)
     end,

--- a/src/object_types/player.lua
+++ b/src/object_types/player.lua
@@ -3,6 +3,7 @@ local map    = require 'map'
 local camera = require 'camera'
 local object = require 'object'
 local opts   = require 'opts'
+local post   = require 'post'
 local sprite = require 'sprite'
 
 return {
@@ -11,6 +12,11 @@ return {
         object.subscribe(this, 'inputdown')
         object.subscribe(this, 'inputup')
         object.subscribe(this, 'ready')
+
+        this.death_sequence = 0.0
+
+        -- Unset any death sequence effects.
+        post.set_grayscale(0)
 
         this.spr_idle = sprite.create('32x32_player.png', 32, 32, 1.5)
         this.spr_walk = sprite.create('32x32_player-walk.png', 32, 32, 0.1)
@@ -50,30 +56,51 @@ return {
         end
     end,
 
-    update = function(this)
+    update = function(this, dt)
         -- Focus the camera on the player.
         local char = this.components.character
-        camera.set_focus_x(char.x + char.w / 2 + char.dx / 2)
 
-        -- Point the camera in the right direction.
-        camera.set_focus_flip(char.direction == 'left')
+        if char then
+            camera.set_focus_x(char.x + char.w / 2 + char.dx / 2)
 
-        if char.jump_enabled then
-            camera.set_focus_y(char.y + char.h / 2)
+            -- Point the camera in the right direction.
+            camera.set_focus_flip(char.direction == 'left')
+
+            if char.jump_enabled then
+                camera.set_focus_y(char.y + char.h / 2)
+            end
+
+            -- Update with panic logic always.
+            camera.set_panic_point(char.x + char.w / 2, char.y + char.h / 2)
+
+            -- Our location is the character's location.
+            this.x = char.x
+            this.y = char.y
+            this.w = char.w
+            this.h = char.h
+
+            -- Charcter died. Remove the component and set our dead flag.
+            if char.dead then
+                object.del_component(this, 'character')
+                this.dead = true
+            end
         end
 
-        -- Update with panic logic always.
-        camera.set_panic_point(char.x + char.w / 2, char.y + char.h / 2)
+        -- If the character dies, start a death sequence.
+        -- Slowly apply a grayscale effect and slow down time.
+        -- This is a little funky because the sequence is time-dependent, while also modifying time during execution
+        -- However, it will still take the same amount of time to complete every time.
+        if this.dead then
+            this.death_sequence = this.death_sequence + dt
 
-        -- Destroy the player if the character dies.
-        if char.dead then
-            object.destroy(this)
+            map.set_time_div(this.death_sequence * 2 + 1)
+
+            if this.death_sequence >= 1.0 then
+                local loc = opts.get('save_location')
+                map.request(loc.map_name, loc.spawn_name)
+            end
+
+            post.set_grayscale(math.min(this.death_sequence, 1.0))
         end
-
-        -- Our location is the character's location.
-        this.x = char.x
-        this.y = char.y
-        this.w = char.w
-        this.h = char.h
     end,
 }

--- a/src/object_types/player.lua
+++ b/src/object_types/player.lua
@@ -14,9 +14,11 @@ return {
         object.subscribe(this, 'ready')
 
         this.death_sequence = 0.0
+        this.death_sequence_max = 0.25
 
         -- Unset any death sequence effects.
         post.set_grayscale(0)
+        camera.setescale(0)
 
         this.spr_idle = sprite.create('32x32_player.png', 32, 32, 1.5)
         this.spr_walk = sprite.create('32x32_player-walk.png', 32, 32, 0.1)
@@ -79,11 +81,16 @@ return {
             this.w = char.w
             this.h = char.h
 
-            -- Charcter died. Remove the component and set our dead flag.
+            -- Character died. Remove the component and set our dead flag.
             if char.dead then
+                this.follow_gib = char.follow_gib
                 object.del_component(this, 'character')
                 this.dead = true
             end
+        else
+            camera.set_focus_x(this.follow_gib.x)
+            camera.set_focus_y(this.follow_gib.y)
+            camera.set_panic_point(this.follow_gib.x, this.follow_gib.y)
         end
 
         -- If the character dies, start a death sequence.
@@ -93,14 +100,15 @@ return {
         if this.dead then
             this.death_sequence = this.death_sequence + dt
 
-            map.set_time_div(this.death_sequence * 2 + 1)
+            map.set_time_div(8 + this.death_sequence * 8)
+            camera.setescale(this.death_sequence * 2)
 
-            if this.death_sequence >= 1.0 then
+            if this.death_sequence >= this.death_sequence_max then
                 local loc = opts.get('save_location')
                 map.request(loc.map_name, loc.spawn_name)
             end
 
-            post.set_grayscale(math.min(this.death_sequence, 1.0))
+            post.set_grayscale(math.min(this.death_sequence / this.death_sequence_max, 1.0))
         end
     end,
 }

--- a/src/post.lua
+++ b/src/post.lua
@@ -1,7 +1,6 @@
 --- Post-processing pipeline manager.
 -- Controls the game rendering pipeline and any post-processing effects.
 
-local log     = require 'log'
 local event   = require 'event'
 local shaders = require 'shaders'
 

--- a/src/post.lua
+++ b/src/post.lua
@@ -1,0 +1,85 @@
+--- Post-processing pipeline manager.
+-- Controls the game rendering pipeline and any post-processing effects.
+
+local log     = require 'log'
+local event   = require 'event'
+local shaders = require 'shaders'
+
+local post = {
+    ready = false,
+    effects = {
+        grayscale = 0,
+    },
+}
+
+--- Prepare a new frame for drawing. Should be called before any game rendering.
+-- Changes the render target to an offscreen texture.
+function post.begin_frame()
+    -- Go ahead and initialize FBs if we haven't already.
+    if not post.ready then
+        post.resize()
+    end
+
+    love.graphics.setCanvas(post.fb_game)
+    love.graphics.clear()
+end
+
+function post.end_frame()
+    -- Perform post-processing steps.
+    -- We only have 1 post shader right now, so just blit it back onto the screen without any alpha blending.
+
+    local source = post.fb_game
+
+    love.graphics.setBlendMode('alpha', 'premultiplied')
+    love.graphics.setColor(1, 1, 1, 1)
+
+    -- Apply grayscale effect
+    source = post.apply_grayscale(source)
+
+    love.graphics.setShader()
+    love.graphics.setCanvas()
+    love.graphics.clear()
+    love.graphics.draw(source)
+
+    -- Re-enable alpha blending for game drawing.
+    love.graphics.setBlendMode('alpha')
+end
+
+--- Set grayscale effect intensity
+-- @param amt Effect intensity. 1 is total grayscale, 0 disables the effect.
+function post.set_grayscale(amt)
+    post.effects.grayscale = amt
+end
+
+--- Apply grayscale effect in pipeline.
+-- Used internally by post.
+-- @param src Source framebuffer.
+-- @return The new source framebuffer.
+function post.apply_grayscale(src)
+    -- Pass through the source if the effect is disabled.
+    if post.effects.grayscale == 0 then
+        return src
+    end
+
+    -- Apply the effect.
+    love.graphics.setShader(shaders.grayscale)
+    shaders.grayscale:send('level', post.effects.grayscale)
+
+    love.graphics.setCanvas(post.fb_grayscale)
+    love.graphics.draw(src)
+
+    return post.fb_grayscale
+end
+
+--- Reinitializes the offscreen framebuffers used in post processing.
+-- Called automatically via event subscription.
+function post.resize()
+    post.fb_game = love.graphics.newCanvas()
+    post.fb_grayscale = love.graphics.newCanvas()
+    post.ready = true
+end
+
+-- Watch for resize events and reconstruct the offscreen framebuffers.
+event.subscribe('fbsize', post.resize)
+
+return post

--- a/src/shaders.lua
+++ b/src/shaders.lua
@@ -9,4 +9,14 @@ shaders.flash = love.graphics.newShader([[
     }
 ]])
 
+shaders.grayscale = love.graphics.newShader([[
+    uniform float level;
+
+    vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords) {
+        vec4 smp = Texel(tex, texture_coords);
+        float lum = dot(smp, vec4(0.2126, 0.7152, 0.0722, 0.0));
+        return level * vec4(lum, lum, lum, smp.a) + (1.0 - level) * smp;
+    }
+]])
+
 return shaders


### PR DESCRIPTION
This PR implements a new subsystem `post` which manages a post-processing rendering pipeline.
A grayscale effect was implemented as a starter.

Maps now have time control. This is demonstrated when the player dies. The grayscale effect is applied and time is slowed down.

After death, the last saved spawn location is loaded.