### PR TITLE
Add automatic map export in launchscript

### DIFF
--- a/boom
+++ b/boom
@@ -1,4 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # boom launch script
 
+# rebuild game maps
+for i in $(dirname $0)/src/assets/maps/*.tmx; do
+    name="${i%.*}"
+    printf "building %s..\n" "$(basename $name)"
+    tiled --export-map lua "$i" "${name}.lua"
+done
+
+echo "starting game.."
 exec love $(dirname $0)/src


### PR DESCRIPTION
Currently maps have to be manually exported to Lua format for the game to recognize them.
This PR adds an auto-generate bit to the launcher script so this is no longer necessary.