### PR TITLE
Fix camera jitter on level load

### DIFF
--- a/src/object_types/player.lua
+++ b/src/object_types/player.lua
@@ -20,6 +20,9 @@ return {
         post.set_grayscale(0)
         camera.setescale(0)
 
+        -- Center the camera on the player initially.
+        camera.center(this.x + this.w / 2, this.y + this.h / 2)
+
         this.spr_idle = sprite.create('32x32_player.png', 32, 32, 1.5)
         this.spr_walk = sprite.create('32x32_player-walk.png', 32, 32, 0.1)
         this.spr_jump = sprite.create('32x32_player-jump.png', 32, 32, 0.05)


### PR DESCRIPTION
The camera does not always start near the player and can quickly jump on level load. This PR ensures the camera is centered on the player initially to prevent this.