### PR TITLE
Compatibility for more setups

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -20,7 +20,7 @@ function love.load()
         love.window.setMode(mode.width, mode.height, mode.flags)
     else
         -- Choose the nicest looking default mode.
-        love.window.setFullscreen(true)
+        love.window.setFullscreen(false)
     end
 
 


### PR DESCRIPTION
# What Changed?
Currently the game runs in fullscreen on first launch. This is known to cause a couple issues with certain setups for some reason, so the game now launches in windowed mode to help with those setups getting started the first time.

This is more of a workaround for the issue, however considering it raises the quality of the project by allowing more people to run, I think it's warrented. If instead we want to implement an override to force windowed launch, perhaps with launch parameters, that can be done as well.