### PR TITLE
Infinite death sequence bugfix

### DIFF
--- a/src/object_types/main_menu.lua
+++ b/src/object_types/main_menu.lua
@@ -160,8 +160,8 @@ return {
                         map.request('intro')
 			opts.set('save_location', {
 			    map_name = 'intro',
-			    spawn_name = dest,
-		    	})
+			    spawn_name = 'intro_0',
+			})
 
 			opts.save()
                     end


### PR DESCRIPTION
# What Changed?
This PR merges the change made by @mitchello457, fixing the continuous death animation that plays if the player manages to die before leaving the first room.

Since the last PR went stale due to his inactivity I have merged his PR to a branch and am re-uploading the PR now, fixing the errors in his branch in the process.