### PR TITLE
Embed Tileset in Map Files

### DIFF
--- a/src/assets/maps/first_zone.lua
+++ b/src/assets/maps/first_zone.lua
@@ -15,7 +15,6 @@ return {
     {
       name = "4096x4096_stone_castle",
       firstgid = 1,
-      filename = "4096x4096_stone_castle.tsx",
       tilewidth = 16,
       tileheight = 16,
       spacing = 0,

--- a/src/assets/maps/first_zone.tmx
+++ b/src/assets/maps/first_zone.tmx
@@ -3,7 +3,9 @@
  <editorsettings>
   <export target="first_zone.lua" format="lua"/>
  </editorsettings>
- <tileset firstgid="1" source="4096x4096_stone_castle.tsx"/>
+ <tileset firstgid="1" name="4096x4096_stone_castle" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="../sprites/4096x4096_stone_castle.png" width="256" height="256"/>
+ </tileset>
  <objectgroup id="7" name="background_sky">
   <object id="52" name="background_sky" type="background" x="16" y="16" width="32" height="32">
    <properties>

--- a/src/assets/maps/intro.lua
+++ b/src/assets/maps/intro.lua
@@ -15,7 +15,6 @@ return {
     {
       name = "4096x4096_stone_castle",
       firstgid = 1,
-      filename = "4096x4096_stone_castle.tsx",
       tilewidth = 16,
       tileheight = 16,
       spacing = 0,

--- a/src/assets/maps/intro.tmx
+++ b/src/assets/maps/intro.tmx
@@ -3,7 +3,9 @@
  <editorsettings>
   <export target="intro.lua" format="lua"/>
  </editorsettings>
- <tileset firstgid="1" source="4096x4096_stone_castle.tsx"/>
+ <tileset firstgid="1" name="4096x4096_stone_castle" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="../sprites/4096x4096_stone_castle.png" width="256" height="256"/>
+ </tileset>
  <objectgroup id="9" name="background_sky"/>
  <objectgroup id="8" name="background_sun"/>
  <objectgroup id="6" name="background_tower"/>

--- a/src/assets/maps/sky.lua
+++ b/src/assets/maps/sky.lua
@@ -15,7 +15,6 @@ return {
     {
       name = "4096x4096_stone_castle",
       firstgid = 1,
-      filename = "4096x4096_stone_castle.tsx",
       tilewidth = 16,
       tileheight = 16,
       spacing = 0,

--- a/src/assets/maps/sky.tmx
+++ b/src/assets/maps/sky.tmx
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="256" height="256" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="61">
- <tileset firstgid="1" source="4096x4096_stone_castle.tsx"/>
+ <tileset firstgid="1" name="4096x4096_stone_castle" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="../sprites/4096x4096_stone_castle.png" width="256" height="256"/>
+ </tileset>
  <objectgroup id="7" name="background_sky">
   <object id="52" name="background_sky" type="background" x="16" y="16" width="32" height="32">
    <properties>

--- a/src/assets/maps/town.lua
+++ b/src/assets/maps/town.lua
@@ -15,7 +15,6 @@ return {
     {
       name = "4096x4096_stone_castle",
       firstgid = 1,
-      filename = "4096x4096_stone_castle.tsx",
       tilewidth = 16,
       tileheight = 16,
       spacing = 0,

--- a/src/assets/maps/town.tmx
+++ b/src/assets/maps/town.tmx
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="256" height="256" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="72">
- <tileset firstgid="1" source="4096x4096_stone_castle.tsx"/>
+ <tileset firstgid="1" name="4096x4096_stone_castle" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="../sprites/4096x4096_stone_castle.png" width="256" height="256"/>
+ </tileset>
  <objectgroup id="7" name="background_sky">
   <object id="52" name="background_sky" type="background" x="2064" y="1296" width="32" height="32">
    <properties>

--- a/src/assets/maps/vale.lua
+++ b/src/assets/maps/vale.lua
@@ -15,7 +15,6 @@ return {
     {
       name = "4096x4096_stone_castle",
       firstgid = 1,
-      filename = "4096x4096_stone_castle.tsx",
       tilewidth = 16,
       tileheight = 16,
       spacing = 0,

--- a/src/assets/maps/vale.tmx
+++ b/src/assets/maps/vale.tmx
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="256" height="256" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="61">
- <tileset firstgid="1" source="4096x4096_stone_castle.tsx"/>
+ <tileset firstgid="1" name="4096x4096_stone_castle" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="../sprites/4096x4096_stone_castle.png" width="256" height="256"/>
+ </tileset>
  <objectgroup id="7" name="background_sky">
   <object id="52" name="background_sky" type="background" x="16" y="16" width="32" height="32">
    <properties>


### PR DESCRIPTION
# What changed?
This PR updates map files (.lua and .tmx) to contain embedded tilesets instead of loading from a .tsx file.

## Maps
I think most of the maps need a complete overhaul to fix level design and tune towards the primary mechanic in the future. That being said, this is a quick fix for a minor bug with the current map files.

closes #124 