### PR TITLE
Fix explosions not working

### DIFF
--- a/src/object_types/explosion.lua
+++ b/src/object_types/explosion.lua
@@ -15,6 +15,10 @@ return {
 
         -- Look for nearby objects to explode.
         map.foreach_object(function (other_obj)
+            if other_obj.x == nil or other_obj.y == nil then
+                return
+            end
+
             local dist = math.sqrt(math.pow(other_obj.x - this.x, 2) + math.pow(other_obj.y - this.y, 2))
 
             if dist < this.object_range then


### PR DESCRIPTION
The explosion object stops iterating over objects if it encounters one without any collision box. This adds an early test to prevent this.